### PR TITLE
AWS Account lift & shift

### DIFF
--- a/terraform/context.tf
+++ b/terraform/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,12 +1,1 @@
-data "aws_route53_zone" "this" {
-  name = var.domain_name
-}
-
-data "aws_acm_certificate" "this" {
-  domain      = var.domain_name
-  types       = ["AMAZON_ISSUED"]
-  statuses    = ["ISSUED"]
-  most_recent = true
-}
-
 data "aws_region" "current" {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,21 +1,24 @@
 module "cdn" {
-  source  = "cloudposse/cloudfront-s3-cdn/aws"
-  version = "0.96.0"
+  source  = "cloudposse/cloudfront-cdn/aws"
+  version = "1.2.0"
 
-  namespace                   = "oares"
-  stage                       = "use1"
-  name                        = "cdn"
-  aliases                     = [local.hostname, join(".", ["mta-sts", var.domain_name])]
-  external_aliases            = var.aliases
-  dns_alias_enabled           = true
-  website_enabled             = true
-  s3_website_password_enabled = true
-  allow_ssl_requests_only     = false
-  price_class                 = "PriceClass_All"
-  default_ttl                 = 86400
-  min_ttl                     = 3600
-  max_ttl                     = 2592000
-  minimum_protocol_version    = "TLSv1.2_2021"
+  name                = "cdn"
+  origin_domain_name  = module.website.bucket_website_domain
+  aliases             = [local.hostname, local.mta_sts]
+  dns_aliases_enabled = true
+  compress            = true
+  price_class         = "PriceClass_All"
+  default_ttl         = 86400
+  min_ttl             = 3600
+  max_ttl             = 2592000
+  parent_zone_id      = aws_route53_zone.this.id
+  acm_certificate_arn = module.acm_certificate.arn
+  context             = module.this.context
+  forward_headers = [
+    "Access-Control-Request-Headers",
+    "Access-Control-Request-Method",
+    "Origin",
+  ]
   custom_error_response = [
     {
       error_caching_min_ttl = null
@@ -24,10 +27,9 @@ module "cdn" {
       response_page_path    = "/404.html"
     }
   ]
-  parent_zone_id      = data.aws_route53_zone.this.zone_id
-  acm_certificate_arn = data.aws_acm_certificate.this.arn
 }
 
 locals {
-  hostname = join(".", compact([var.host_name, var.domain_name]))
+  hostname = join(".", compact([var.host_name, aws_route53_zone.this.name]))
+  mta_sts  = join(".", ["mta-sts", aws_route53_zone.this.name])
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -4,11 +4,11 @@ output "cloudFrontDistributionID" {
 }
 
 output "s3Bucket" {
-  value       = module.cdn.s3_bucket
+  value       = module.website.bucket_id
   description = "AWS S3 Bucket name"
 }
 
 output "hostname" {
-  value       = module.cdn.aliases[0]
+  value       = module.cdn.cf_domain_name
   description = "Base hostname used for Cloudfront Distibution"
 }

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,0 +1,42 @@
+resource "aws_route53_zone" "this" {
+  name          = var.domain_name
+  comment       = var.comment
+  force_destroy = false
+
+  lifecycle {
+    ignore_changes = [vpc]
+  }
+}
+
+module "website" {
+  source  = "cloudposse/s3-bucket/aws"
+  version = "4.10.0"
+
+  bucket_name         = aws_route53_zone.this.name
+  s3_object_ownership = "BucketOwnerEnforced"
+  versioning_enabled  = false
+  context             = module.this.context
+  website_configuration = [
+    {
+      index_document = "index.html"
+      error_document = "/404.html"
+      routing_rules  = null
+    }
+  ]
+}
+
+module "acm_certificate" {
+  source  = "cloudposse/acm-request-certificate/aws"
+  version = "0.18.0"
+
+  domain_name                       = aws_route53_zone.this.name
+  zone_id                           = aws_route53_zone.this.id
+  process_domain_validation_options = true
+  ttl                               = "300"
+  subject_alternative_names         = [join(".", ["*", aws_route53_zone.this.name])]
+}
+
+locals {
+  caa_report_recipient = can(regex("@", var.caa_report_recipient)) ? var.caa_report_recipient : "${var.caa_report_recipient}@${aws_route53_zone.this.name}"
+  tls_report_recipient = can(regex("@", var.tls_report_recipient)) ? var.tls_report_recipient : "${var.tls_report_recipient}@${aws_route53_zone.this.name}"
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,3 +1,13 @@
+namespace = "osceolaares"
+
+stage = "use1"
+
 domain_name = "osceolacountyares.org"
+
+comment = "Osceola County ARES"
+
+mx_records = [
+  "1 SMTP.GOOGLE.COM",
+]
 
 host_name = "staging"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,16 +1,81 @@
 variable "domain_name" {
+  description = "AWS Route53 Hosted Zone domain name"
   type        = string
-  description = "The domain name to host site"
+}
+
+variable "comment" {
+  description = "AWS Route53 Hosted Zone comment"
+  type        = string
+}
+
+variable "caa_report_recipient" {
+  description = "Recipient of CAA reports"
+  type        = string
+  default     = "hostmaster"
+}
+
+variable "caa_issuers" {
+  description = "List of Certificate authories authorized to issue certificates"
+  type        = list(string)
+  default     = ["amazon.com"]
+}
+
+variable "tls_report_recipient" {
+  description = "Recipient of SMTP TLS Reports"
+  type        = string
+  default     = "smtp-tls-reports"
+}
+
+variable "mx_records" {
+  description = "List of MX Records"
+  type        = list(string)
+  default     = []
+}
+
+variable "mta_sts_mode" {
+  description = "MTA Strict Transport Security mode, defaults to testing"
+  type        = string
+  default     = "testing"
+}
+
+variable "dmarc_version" {
+  description = "SMTP DMARC Reporting version, defaults to DMARC1"
+  type        = string
+  default     = ""
+}
+
+variable "dmarc_mailbox" {
+  description = "SMTP DMARC Reporting mailbox, defaults to noreply-dmarc-support"
+  type        = string
+  default     = ""
+}
+
+variable "dmarc_domain" {
+  description = "SMTP DMARC Reporting domain, defaults to current domain"
+  type        = string
+  default     = ""
+}
+
+variable "dmarc_additional_rua" {
+  description = "SMTP DMARC Reporting additional RUA"
+  type        = string
+  default     = ""
+}
+
+variable "additional_dkim" {
+  description = "Additional DKIM TXT records to add"
+  type        = map(string)
+  default     = {}
 }
 
 variable "aliases" {
-  type        = list(string)
   description = "Additional aliases for Cloudfront"
+  type        = list(string)
   default     = []
 }
 
 variable "host_name" {
-  type        = string
   description = "The host name for the site"
+  type        = string
   default     = null
 }


### PR DESCRIPTION
Move the deployment into new dedicated AWS Account for Osceola ARES

- Add creation of Route53 Hosted Zone
- Convert from cloudfront-s3-cdn module to s3-bucket and cloudfront-cdn modules.