### PR TITLE
fix: add custom rule for atproto-did redirection in Amplify app

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,6 +10,12 @@ resource "aws_amplify_app" "website" {
   }
 
   custom_rule {
+    source = "/.well-known/atproto-did"
+    status = "200"
+    target = "/well-known/atproto-did.txt"
+  }
+  
+  custom_rule {
     source = "/.well-known/<*>"
     status = "200"
     target = "/well-known/<*>"


### PR DESCRIPTION
Adds custom rule for atproto-did redirection

Implements a new custom rule in the Amplify app to redirect requests from /.well-known/atproto-did to /well-known/atproto-did.txt.

This change improves accessibility for users seeking the atproto-did resource, ensuring they receive the correct content with a 200 status response.